### PR TITLE
DOP-1186 Remove set output from versiontool

### DIFF
--- a/github-action.sh
+++ b/github-action.sh
@@ -13,8 +13,8 @@ fi
 
 if [ "$INPUT_OPERATION" == "sort" ] || [ "$INPUT_OPERATION" == "highest" ]; then
   set -x
-  echo "::set-output name=result::"$( /versiontool "$INPUT_OPERATION" $INPUT_FLAGS < "$INPUT_VERSION")
+  echo "result="$( /versiontool "$INPUT_OPERATION" $INPUT_FLAGS < "$INPUT_VERSION") >> $GITHUB_OUTPUT
   exit
 fi
 set -x
-echo "::set-output name=result::"$(/versiontool $prefix $strict "$INPUT_OPERATION" $INPUT_FLAGS "$INPUT_VERSION")
+echo "result="$(/versiontool $prefix $strict "$INPUT_OPERATION" $INPUT_FLAGS "$INPUT_VERSION") >> $GITHUB_OUTPUT


### PR DESCRIPTION
Changing from ::set-output:: to >> $GITHUB_OUTPUT
